### PR TITLE
Use Ruby 3.3.3 and cleanup TTY

### DIFF
--- a/.github/workflows/cli_deploy.yml
+++ b/.github/workflows/cli_deploy.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up Ruby and install dependencies
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '3.2.2'
+          ruby-version: '3.3.3'
           bundler-cache: true
 
       - name: Install dependencies

--- a/.github/workflows/cli_tests.yml
+++ b/.github/workflows/cli_tests.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '3.2.2'
+          ruby-version: '3.3.3'
           bundler-cache: true
 
       - name: Run Rubocop
@@ -27,7 +27,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
-        ruby-version: ['3.2.2']
+        ruby-version: ['3.3.3']
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -54,7 +54,7 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '3.2.2'
+          ruby-version: '3.3.3'
           bundler-cache: true
 
       - name: Create test images directory

--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ gemspec
 group :development, :test do
   gem 'minitest', '~> 5.25.1'
   gem 'minitest-reporters', '~> 1.7.1'
-  gem 'pry', '~> 0.15.0'
+  gem 'pry-byebug', '~> 3.10'
   gem 'rake', '~> 13.2.1'
   gem 'rspec', '~> 3.13.0'
   gem 'rubocop', '~> 1.68.0'

--- a/emerge_cli.gemspec
+++ b/emerge_cli.gemspec
@@ -32,7 +32,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'chunky_png', '~> 1.4.0'
   spec.add_dependency 'dry-cli', '~> 1.2.0'
   spec.add_dependency 'open3', '~> 0.2.1'
-  spec.add_dependency 'pry-byebug', '~> 3.8'
   spec.add_dependency 'ruby_tree_sitter', '~> 1.9'
   spec.add_dependency 'tty-prompt', '~> 0.23.1'
   spec.add_dependency 'tty-table', '~> 0.12.0'

--- a/lib/commands/reaper/reaper.rb
+++ b/lib/commands/reaper/reaper.rb
@@ -23,6 +23,7 @@ module EmergeCLI
       def call(**options)
         @options = options
         @profiler = EmergeCLI::Profiler.new(enabled: options[:profile])
+        @prompt = TTY::Prompt.new
         before(options)
         success = false
 
@@ -88,8 +89,6 @@ module EmergeCLI
       def prompt_class_selection(unseen_classes)
         return nil if unseen_classes.empty?
 
-        prompt = TTY::Prompt.new
-
         choices = unseen_classes.map do |item|
           display_name = if item['paths']&.first
                            "#{item['class_name']} (#{item['paths'].first})"
@@ -102,7 +101,7 @@ module EmergeCLI
           }
         end
 
-        prompt.multi_select(
+        @prompt.multi_select(
           'Select classes to delete:'.blue,
           choices,
           per_page: 15,
@@ -113,8 +112,7 @@ module EmergeCLI
       end
 
       def confirm_deletion(count)
-        prompt = TTY::Prompt.new
-        prompt.yes?("Are you sure you want to delete #{count} class#{count > 1 ? 'es' : ''}?")
+        @prompt.yes?("Are you sure you want to delete #{count} type#{count > 1 ? 's' : ''}?")
       end
 
       class DeadCodeResult


### PR DESCRIPTION
Ruby 3.3.3 silences some experimental warnings that get output by our CLI.