### PR TITLE
Collect all paginated Reaper results

### DIFF
--- a/lib/commands/reaper/reaper.rb
+++ b/lib/commands/reaper/reaper.rb
@@ -91,20 +91,11 @@ module EmergeCLI
           data = JSON.parse(response.read)
 
           if combined_data.nil?
-            combined_data = data  # First page, use as base
+            combined_data = data
           else
-            # Merge dead_code arrays
             combined_data['dead_code'].concat(data.fetch('dead_code', []))
-
-            # Update counts safely
-            counts = combined_data['counts']
-            new_counts = data.dig('counts') || {}
-
-            counts['seen_classes'] += new_counts.fetch('seen_classes', 0)
-            counts['unseen_classes'] += new_counts.fetch('unseen_classes', 0)
           end
 
-          # Check if we've reached the last page
           current_page = data.dig('pagination', 'current_page')
           total_pages = data.dig('pagination', 'total_pages')
 


### PR DESCRIPTION
Our export API only returns results 25k at a time since it doesn't truncate any of the path information (yet) like our web UI API does. This will iterate through all pages before starting the deletion prompt.