### PR TITLE
Remove pry import for now

### DIFF
--- a/lib/emerge_cli.rb
+++ b/lib/emerge_cli.rb
@@ -25,8 +25,6 @@ require_relative 'utils/project_detector'
 require_relative 'utils/version_check'
 
 require 'dry/cli'
-require 'pry'
-require 'pry-byebug'
 
 module EmergeCLI
   extend Dry::CLI::Registry


### PR DESCRIPTION
This is only a `:development` dependency, will have to figure out later on a better way to manage this.