### PR TITLE
Remove pry require from production releases

### DIFF
--- a/.github/workflows/cli_tests.yml
+++ b/.github/workflows/cli_tests.yml
@@ -37,6 +37,11 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y imagemagick
+
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:

--- a/.github/workflows/cli_tests.yml
+++ b/.github/workflows/cli_tests.yml
@@ -39,8 +39,13 @@ jobs:
 
       - name: Install dependencies
         run: |
-          sudo apt-get update
-          sudo apt-get install -y imagemagick
+          if [ "$RUNNER_OS" == "Linux" ]; then
+            sudo apt-get update
+            sudo apt-get install -y imagemagick
+          elif [ "$RUNNER_OS" == "macOS" ]; then
+            brew install imagemagick
+          fi
+        shell: bash
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1

--- a/.github/workflows/cli_tests.yml
+++ b/.github/workflows/cli_tests.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '3.3.3'
+          ruby-version: "3.3.3"
           bundler-cache: true
 
       - name: Run Rubocop
@@ -29,23 +29,13 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
-        ruby-version: ['3.3.3']
+        ruby-version: ["3.3.3"]
     runs-on: ${{ matrix.os }}
 
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-
-      - name: Install dependencies
-        run: |
-          if [ "$RUNNER_OS" == "Linux" ]; then
-            sudo apt-get update
-            sudo apt-get install -y imagemagick
-          elif [ "$RUNNER_OS" == "macOS" ]; then
-            brew install imagemagick
-          fi
-        shell: bash
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
@@ -70,8 +60,18 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '3.3.3'
+          ruby-version: "3.3.3"
           bundler-cache: true
+
+      - name: Install dependencies
+        run: |
+          if [ "$RUNNER_OS" == "Linux" ]; then
+            sudo apt-get update
+            sudo apt-get install -y imagemagick
+          elif [ "$RUNNER_OS" == "macOS" ]; then
+            brew install imagemagick
+          fi
+        shell: bash
 
       - name: Create test images directory
         run: |

--- a/lib/emerge_cli.rb
+++ b/lib/emerge_cli.rb
@@ -31,7 +31,6 @@ require_relative 'utils/macho_parser'
 require_relative 'utils/version_check'
 
 require 'dry/cli'
-require 'pry-byebug'
 
 module EmergeCLI
   extend Dry::CLI::Registry


### PR DESCRIPTION
This accidentally slipped in, I usually only include it locally since it's a development dependency.