### PR TITLE
Fix console warnings

### DIFF
--- a/emerge_cli.gemspec
+++ b/emerge_cli.gemspec
@@ -40,6 +40,8 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'tty-prompt', '~> 0.23.1'
   spec.add_dependency 'tty-table', '~> 0.12.0'
   spec.add_dependency 'xcodeproj', '~> 1.27.0'
+  spec.add_dependency 'nkf', '~> 0.1.3'
+  spec.add_dependency 'base64', '~> 0.2.0'
 
   spec.metadata['rubygems_mfa_required'] = 'true'
 end

--- a/emerge_cli.gemspec
+++ b/emerge_cli.gemspec
@@ -30,9 +30,11 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'async-http', '~> 0.86.0'
+  spec.add_dependency 'base64', '~> 0.2.0'
   spec.add_dependency 'CFPropertyList', '~> 2.3', '>= 2.3.2'
   spec.add_dependency 'chunky_png', '~> 1.4.0'
   spec.add_dependency 'dry-cli', '~> 1.2.0'
+  spec.add_dependency 'nkf', '~> 0.1.3'
   spec.add_dependency 'open3', '~> 0.2.1'
   spec.add_dependency 'ruby-macho', '~> 4.1.0'
   spec.add_dependency 'ruby_tree_sitter', '~> 1.9'
@@ -40,8 +42,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'tty-prompt', '~> 0.23.1'
   spec.add_dependency 'tty-table', '~> 0.12.0'
   spec.add_dependency 'xcodeproj', '~> 1.27.0'
-  spec.add_dependency 'nkf', '~> 0.1.3'
-  spec.add_dependency 'base64', '~> 0.2.0'
 
   spec.metadata['rubygems_mfa_required'] = 'true'
 end

--- a/lib/version.rb
+++ b/lib/version.rb
@@ -1,3 +1,3 @@
 module EmergeCLI
-  VERSION = '0.6.0'.freeze
+  VERSION = '0.6.1'.freeze
 end


### PR DESCRIPTION
I missed these warnings being printed in the console:
```
➜  emerge-cli git:(telkins/0.6.0) ✗ emerge build-distribution install --build-id "549b63e1-3eea-4c2c-bc6c-ca7a2de1e853"
Resolving dependencies...
/Users/telkins/.rvm/gems/ruby-3.3.3/gems/CFPropertyList-2.3.6/lib/cfpropertylist/rbCFPropertyList.rb:3: warning: kconv is found in nkf, which will no longer be part of the default gems since Ruby 3.4.0. Add nkf to your Gemfile or gemspec. Also contact author of CFPropertyList-2.3.6 to add nkf into its gemspec.
/Users/telkins/.rvm/gems/ruby-3.3.3/gems/CFPropertyList-2.3.6/lib/cfpropertylist/rbCFTypes.rb:10: warning: base64 was loaded from the standard library, but will no longer be part of the default gems since Ruby 3.4.0. Add base64 to your Gemfile or gemspec. Also contact author of CFPropertyList-2.3.6 to add base64 into its gemspec.
```