### PR TITLE
Device picker for installing Android builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,7 @@ Gemfile.lock
 
 # DS_Store
 .DS_Store
+
+# Ignore build files downloaded for testing
+*.apk
+*.ipa

--- a/lib/commands/build/distribution/install.rb
+++ b/lib/commands/build/distribution/install.rb
@@ -128,11 +128,41 @@ module EmergeCLI
           end
 
           def install_android_build(build_path)
-            command = "adb -s #{@options[:device_id]} install #{build_path}"
+            device_id = @options[:device_id] || select_android_device
+            raise 'No Android devices found' unless device_id
+
+            command = "adb -s #{device_id} install #{build_path}"
             Logger.debug "Running command: #{command}"
             `#{command}`
 
             Logger.info '✅ Build installed'
+          end
+
+          def select_android_device
+            devices = get_android_devices
+            return nil if devices.empty?
+            return devices.first if devices.length == 1
+
+            Logger.info 'Multiple Android devices found. Please select one:'
+            devices.each_with_index do |device, index|
+              Logger.info "#{index + 1}. #{device}"
+            end
+
+            print 'Enter device number: '
+            selection = STDIN.gets.chomp.to_i
+            return devices[selection - 1] if selection.between?(1, devices.length)
+
+            raise 'Invalid device selection'
+          end
+
+          def get_android_devices
+            output = `adb devices`
+            # Split output into lines, remove first line (header), and extract device IDs
+            devices = output.split("\n")[1..]
+                          .map(&:strip)
+                          .reject(&:empty?)
+                          .map { |line| line.split("\t").first }
+            devices
           end
         end
       end

--- a/lib/commands/build/distribution/install.rb
+++ b/lib/commands/build/distribution/install.rb
@@ -158,11 +158,10 @@ module EmergeCLI
           def get_android_devices
             output = `adb devices`
             # Split output into lines, remove first line (header), and extract device IDs
-            devices = output.split("\n")[1..]
-                          .map(&:strip)
-                          .reject(&:empty?)
-                          .map { |line| line.split("\t").first }
-            devices
+            output.split("\n")[1..]
+                  .map(&:strip)
+                  .reject(&:empty?)
+                  .map { |line| line.split("\t").first }
           end
         end
       end

--- a/lib/commands/build/distribution/install.rb
+++ b/lib/commands/build/distribution/install.rb
@@ -3,6 +3,7 @@ require 'cfpropertylist'
 require 'zip'
 require 'rbconfig'
 require 'tmpdir'
+require 'tty-prompt'
 
 module EmergeCLI
   module Commands
@@ -143,16 +144,9 @@ module EmergeCLI
             return nil if devices.empty?
             return devices.first if devices.length == 1
 
-            Logger.info 'Multiple Android devices found. Please select one:'
-            devices.each_with_index do |device, index|
-              Logger.info "#{index + 1}. #{device}"
-            end
-
-            print 'Enter device number: '
-            selection = STDIN.gets.chomp.to_i
-            return devices[selection - 1] if selection.between?(1, devices.length)
-
-            raise 'Invalid device selection'
+            prompt = TTY::Prompt.new
+            Logger.info 'Multiple Android devices found.'
+            prompt.select('Choose a device:', devices)
           end
 
           def get_android_devices


### PR DESCRIPTION
For Android builds
* When no devices are connected:
  * Show error message
* When one device is connected:
  * Install automatically to that device
* When multiple devices are connect:
  * Show device picker
  
  
 Here’s a screenshot of the three things in that order.
![image](https://github.com/user-attachments/assets/24c2de48-a10c-47ef-b40f-2cc9ae9ec458)
