### PR TITLE
Don't explicitly finish the run for batch snapshots

### DIFF
--- a/lib/commands/upload/snapshots/snapshots.rb
+++ b/lib/commands/upload/snapshots/snapshots.rb
@@ -75,7 +75,7 @@ module EmergeCLI
 
               upload_images(run_id, options[:concurrency], image_files, client)
 
-              @profiler.measure('finish_run') { finish_run(run_id) }
+              @profiler.measure('finish_run') { finish_run(run_id) } unless options[:batch]
             end
 
             Logger.info 'Upload completed successfully!'

--- a/lib/version.rb
+++ b/lib/version.rb
@@ -1,3 +1,3 @@
 module EmergeCLI
-  VERSION = '0.7.5'.freeze
+  VERSION = '0.7.6'.freeze
 end


### PR DESCRIPTION
There's no need to signal the finish of a run for batch snapshots since this happens automatically when the `manifest.json` file is processed. Realized this was causing it to trigger our finish logic twice.